### PR TITLE
Http404 on invalid fingerprint hash

### DIFF
--- a/emif/population_characteristics/documents.py
+++ b/emif/population_characteristics/documents.py
@@ -54,6 +54,8 @@ from accounts.models import EmifProfile
 
 from django.core.exceptions import PermissionDenied
 
+from django.http import Http404
+
 def document_form_view_upload(request, fingerprint_id, template_name='documents_upload_form.html'):
     """Store the files at the backend
     """
@@ -152,6 +154,17 @@ def document_form_view(request, runcode, qs, activetab='summary', readOnly=False
 
     if "query" in request.session and "highlight_results" in request.session:
         h = request.session["highlight_results"]
+
+    # GET fingerprint primary key (for comments)
+    fingerprint = None
+
+    try:
+        fingerprint = Fingerprint.objects.get(fingerprint_hash=runcode)
+        fingerprint_pk = fingerprint.id
+    except:
+        fingerprint_pk = 0
+        raise Http404
+
     qsets, name, db_owners, fingerprint_ttype = createqsets(runcode, highlights=h)
 
     if fingerprint_ttype == "":
@@ -198,14 +211,6 @@ def document_form_view(request, runcode, qs, activetab='summary', readOnly=False
         isAdvanced = False
 
     qsets = attachPermissions(runcode, qsets)
-    # GET fingerprint primary key (for comments)
-    fingerprint = None
-
-    try:
-        fingerprint = Fingerprint.objects.get(fingerprint_hash=runcode)
-        fingerprint_pk = fingerprint.id
-    except:
-        fingerprint_pk = 0
 
     jerboa_files = Characteristic.objects.filter(fingerprint_id=runcode).order_by('-latest_date')
 


### PR DESCRIPTION
- When trying to access an unexistant fingerprint hash, internal error was being thrown instead of a 404.